### PR TITLE
Use 'safe-access' version of netCDF4.VLType 

### DIFF
--- a/lib/iris/fileformats/netcdf/_thread_safe_nc.py
+++ b/lib/iris/fileformats/netcdf/_thread_safe_nc.py
@@ -20,6 +20,7 @@ _GLOBAL_NETCDF4_LOCK = Lock()
 # Doesn't need thread protection, but this allows all netCDF4 refs to be
 #  replaced with thread_safe refs.
 default_fillvals = netCDF4.default_fillvals
+VLType = netCDF4.VLType
 
 
 class _ThreadSafeWrapper(ABC):

--- a/lib/iris/fileformats/netcdf/loader.py
+++ b/lib/iris/fileformats/netcdf/loader.py
@@ -219,7 +219,7 @@ def _get_cf_var_data(cf_var, filename):
         # arrays as the size of the array can only be known by reading the data.
         # "Variable length" netCDF types have a datatype of `nc.VLType`.
         if isinstance(
-            getattr(cf_var, "datatype", None), _thread_safe_nc.netCDF4.VLType
+            getattr(cf_var, "datatype", None), _thread_safe_nc.VLType
         ):  # TODO(ChrisB): I am accessing netCDF4 directly here - is this ok? Just for type comparison.
             # We can't know the size of VLen data without reading the variable from disk
             # first; see https://github.com/Unidata/netcdf-c/issues/1893

--- a/lib/iris/tests/unit/fileformats/netcdf/loader/test__get_cf_var_data.py
+++ b/lib/iris/tests/unit/fileformats/netcdf/loader/test__get_cf_var_data.py
@@ -11,11 +11,11 @@ import iris.tests as tests  # isort:skip
 from unittest import mock
 
 import dask.array as da
-from netCDF4 import VLType
 import numpy as np
 
 from iris._lazy_data import _optimum_chunksize
 import iris.fileformats.cf
+from iris.fileformats.netcdf._thread_safe_nc import VLType
 from iris.fileformats.netcdf.loader import CHUNK_CONTROL, _get_cf_var_data
 
 


### PR DESCRIPTION
Aims to fix coding-standards test failure on https://github.com/SciTools/iris/pull/6340

Because the "test_netcdf4_import" test checks that nothing imports directly from `netCDF4`
So I exposed a copy of `VLType` in the "safe" netcdf4 mirror module + use that